### PR TITLE
Update segments-importing: 40->250 attributes by default

### DIFF
--- a/doc-source/segments-importing.md
+++ b/doc-source/segments-importing.md
@@ -229,4 +229,4 @@ You can replace attribute names that are shown as `custom_attribute` with any va
 | User\.UserAttributes\.custom\_attribute | A custom attribute that describes the user\. You can replace custom\_attribute with any value, such as FirstName or Age\. | 
 | User\.UserId | A unique identifier for the user\. | 
 
-You can create as many as 40 custom attributes for endpoints and users in each project\. For more information, see [Amazon Pinpoint Quotas](https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html) in the *Amazon Pinpoint Developer Guide*\.
+You can create as many as 250 custom attributes for endpoints and users in each project by default\. For more information, see [Amazon Pinpoint Quotas](https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html) in the *Amazon Pinpoint Developer Guide*\.


### PR DESCRIPTION
Pinpoint allows 250 attributes by default now (as per https://docs.aws.amazon.com/pinpoint/latest/developerguide/quotas.html#quotas-endpoint).

*Issue #, if available:*

*Description of changes:*
Max attribute note updated to reflect recent changes in the product.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
