### PR TITLE
Unable to Publish SMS from pinpoint to SNS topic if the key policy has service as "sms-voice.amazonaws.com" when SNS is encrypted

### DIFF
--- a/doc-source/channels-sms-two-way.md
+++ b/doc-source/channels-sms-two-way.md
@@ -48,7 +48,7 @@ You can only enable two\-way SMS for a phone number if the value in the **SMS** 
      {
        "Effect": "Allow",
        "Principal": {
-         "Service": "sms-voice.amazonaws.com"
+         "Service": "mobile.amazonaws.com"
        },
        "Action": "sns:Publish",
        "Resource": "*"
@@ -75,7 +75,7 @@ Second, the key policy must be modified to allow Amazon Pinpoint to use the key\
 {
     "Effect": "Allow",
     "Principal": {
-        "Service": "sms-voice.amazonaws.com"
+        "Service": "mobile.amazonaws.com"
     },
     "Action": [
         "kms:GenerateDataKey*",


### PR DESCRIPTION
…com"

I had created an SNS topics encrypted with customer managed key but it was not allowing me to publish message from pinpoint to SNS topic. I added the policy mentioned for the cmk but no effect, later it worked when the service was updated to "mobile.amazonaws.com".

*Issue #, if available:*
SMS from Pinpoint is not published to encrypted SNS topic if the service is mentioned as "sms-voice.amazonaws.com" in the cmk kms policy

*Description of changes:*
In the cmk policy "sms-voice.amazonaws.com" is updated to "mobile.amazonaws.com"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
