### PR TITLE
Update message-template-helpers.md

### DIFF
--- a/doc-source/message-template-helpers.md
+++ b/doc-source/message-template-helpers.md
@@ -52,7 +52,7 @@ In this example, the `if` helper is used to evaluate whether a user's first name
 `{{else}}`  
 *Hello,*  
 `{{/if}}`  
-returns *Hello, Jane* if the `if` helper is true\.
+returns *Hello Jane,* if the `if` helper is true\.
 
 ## Conditional helpers<a name="conditionhelpers"></a>
 


### PR DESCRIPTION
Fixed typo in example

*Issue #, if available:*

*Description of changes:*
The example shows `,` after the name, but example result shows it between **Hello** and _name_

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
